### PR TITLE
Ensure proposals are from the real proposer

### DIFF
--- a/src/hotstuff.cpp
+++ b/src/hotstuff.cpp
@@ -211,6 +211,11 @@ void HotStuffBase::propose_handler(MsgPropose &&msg, const Net::conn_t &conn) {
         LOG_WARN("invalid proposal from %d", prop.proposer);
         return;
     }
+    if (prop.proposer != pmaker->get_proposer())
+    {
+        LOG_WARN("received proposal from %d who is not the proposer", prop.proposer);
+        return;
+    }
     promise::all(std::vector<promise_t>{
         async_deliver_blk(blk->get_hash(), peer)
     }).then([this, prop = std::move(prop)]() {


### PR DESCRIPTION
Closes #22

When a node receives a proposal, it should check the sender is the current proposer. Otherwise, there is no liveness, as discussed in the issue.

I fixed this by adding an if condition to verify the identity of the proposer. If a proposal is sent from other nodes, this proposal is ignored.